### PR TITLE
Add default values to the webhook configuration

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: navlinkswebhook
 description: A Helm chart for Admission Webhook to create Navlinks for Prometheus
 type: application
-version: 2.0.0
+version: 2.0.1
 appVersion: "2.0.0"
 maintainers:
-  - name: eumel8
-    email: f.kloeker@telekom.de
-    url: https://www.telekom.com
+- name: eumel8
+  email: f.kloeker@telekom.de
+  url: https://www.telekom.com

--- a/chart/templates/admission.yaml
+++ b/chart/templates/admission.yaml
@@ -21,6 +21,7 @@ webhooks:
   - admissionReviewVersions:
     - v1
     name: {{ .Values.admission.webhook.name }}
+    matchPolicy: {{ .Values.admission.matchPolicy }}
     namespaceSelector:
       matchExpressions:
         - key: kubernetes.io/metadata.name
@@ -31,11 +32,15 @@ webhooks:
         name: {{ include "navlinkswebhook.fullname" . }}
         namespace: {{ .Release.Namespace | default "default" }}
         path: "/validate"
+        port: 443
       caBundle: {{ $ca.Cert | b64enc }}
     rules:
       - operations: ["CREATE","DELETE"]
         apiGroups: ["monitoring.coreos.com"]
         apiVersions: ["v1"]
         resources: ["prometheuses"]
+        scope: "*"
+    objectSelector: {}
     failurePolicy: {{ .Values.admission.failurePolicy }}
     sideEffects: {{ .Values.admission.sideEffects }}
+    timeoutSeconds: {{ .Values.admission.timeoutSeconds }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -24,6 +24,8 @@ admission:
     name: webhook.example.com
   # list of excluded namespaces, comma-separated
   # exclude: default, kube-system, cattle-system
+  matchPolicy: Equivalent
+  timeoutSeconds: 10
 
 podAnnotations: {}
 


### PR DESCRIPTION
## Motivation

Same as in the https://github.com/eumel8/cosignwebhook/pull/64 - using GitOps agents who rely heavily on helm (like Rancher's fleet) creates a discrepancy between the created validatingwebhookconfiguration of a cluster and the expected manifest, as rendered via the helm templating engine. 

Since a couple of fields are missing, the monitored GitOps resource is never reconciled, as it's always in a modified state.

This PR adds the "missing" fields, which are sensible defaults.

## Tests done

Runs like this in 30+ k8s clusters in our internal CaaS plattform :)

## Impact

Updating will unfortunately cause a redeployment of the webhook server. Other than that, nothing major happened,