### PR TITLE
Add default hardened network policy

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: navlinkswebhook
 description: A Helm chart for Admission Webhook to create Navlinks for Prometheus
 type: application
-version: 2.1.0
+version: 2.1.0-rc2
 appVersion: "2.0.1"
 maintainers:
 - name: eumel8

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: navlinkswebhook
 description: A Helm chart for Admission Webhook to create Navlinks for Prometheus
 type: application
-version: 2.0.1
+version: 2.1.0
 appVersion: "2.0.1"
 maintainers:
 - name: eumel8

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: navlinkswebhook
 description: A Helm chart for Admission Webhook to create Navlinks for Prometheus
 type: application
-version: 2.1.0-rc2
+version: 2.1.0
 appVersion: "2.0.1"
 maintainers:
 - name: eumel8

--- a/chart/templates/networkpolicy.yaml
+++ b/chart/templates/networkpolicy.yaml
@@ -1,0 +1,18 @@
+{{ - if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-to-target-port
+  labels:
+    {{- include "navlinkswebhook.labels" . | nindent 4 }}
+spec:
+  podSelector:
+      matchLabels:
+          {{- include "navlinkswebhook.labels" . | nindent 6 }}
+  policyTypes:
+      - Ingress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: {{ .Values.service.targetPort }}
+{{ - end }}

--- a/chart/templates/networkpolicy.yaml
+++ b/chart/templates/networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{ - if .Values.networkPolicy.enabled }}
+{{- if .Values.networkPolicy.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -8,11 +8,11 @@ metadata:
 spec:
   podSelector:
       matchLabels:
-          {{- include "navlinkswebhook.labels" . | nindent 6 }}
+          {{- include "navlinkswebhook.labels" . | nindent 8 }}
   policyTypes:
       - Ingress
   ingress:
   - ports:
     - protocol: TCP
       port: {{ .Values.service.targetPort }}
-{{ - end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -69,6 +69,11 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+networkPolicy:
+  # whether to enable a hardened network policy for the pod
+  # to only allow ingress
+  enabled: true
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
## Motivation

RKE2 clusters require explicit network policy to allow communication to the webhook server, since the kubeapi server now runs in a pod in the kube-system namespace. Even though all communication from the kube-system project is allowed by default in rancher (when project isolation is activated), somehow the requests aren't going through to the webhook...

Creating a default explicit network policy for the webhook is the most secure way to establish that, regardless on what the underlying problem is. If other users don't need the netpol, they may disable it with the new value toggle.

## Tests done

- [x] works in a staging CaaS RKE1 cluster (new navlinks get created)
- [x] works in a staging CaaS RKE2 cluster
